### PR TITLE
feat(frontend): fetch and display products from backend API

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -10,6 +10,11 @@
 - Node.js (recomendado: LTS)
 - pnpm
 
+## Configuración
+
+Crear un archivo `.env.local` en la carpeta `frontend` con:
+NEXT_PUBLIC_API_BASE_URL=http://localhost:8080
+
 ## Ejecutar
 
 1. Instalar dependencias:
@@ -21,5 +26,5 @@ pnpm install
 2. Levantar el servidor:
 
 ```bash
-pnpm run dev
+pnpm dev
 ```

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,38 +1,40 @@
-"use client";
+import { apiGet } from "@/lib/api";
+import { Product } from "@/types/product";
+import { ProductList } from "@/components/ProductList";
 
-import { useEffect, useState } from "react";
-
-interface Product {
-  id: number;
-  name: string;
-  price: number;
+async function getProducts(): Promise<Product[]> {
+  return apiGet<Product[]>("/products");
 }
 
-export default function Home() {
-  const [products, setProducts] = useState<Product[]>([]);
+export default async function Home() {
+  let products: Product[] = [];
+  let error: string | null = null;
 
-  useEffect(() => {
-    async function fetchProducts() {
-      const response = await fetch(
-        `${process.env.NEXT_PUBLIC_API_BASE_URL}/products`
-      );
-      const data = await response.json();
-      setProducts(data);
-    }
-
-    fetchProducts();
-  }, []);
+  try {
+    products = await getProducts();
+  } catch (e) {
+    error = (e as Error).message ?? "Error desconocido al obtener productos";
+  }
 
   return (
-    <div>
-      <h1>Productos</h1>
-      <ul>
-        {products.map((product) => (
-          <li key={product.id}>
-            {product.name} - ${product.price}
-          </li>
-        ))}
-      </ul>
-    </div>
+    <main className="mx-auto max-w-2xl p-6">
+      <h1 className="text-2xl font-bold">Productos</h1>
+      <p className="mt-1 text-sm text-gray-600">
+        Backend:&nbsp;
+        <code className="rounded bg-gray-100 px-1 py-0.5">
+          {process.env.NEXT_PUBLIC_API_BASE_URL}
+        </code>
+      </p>
+
+      <section className="mt-6">
+        {error ? (
+          <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+            Error cargando productos: {error}
+          </div>
+        ) : (
+          <ProductList products={products} />
+        )}
+      </section>
+    </main>
   );
 }

--- a/frontend/src/components/ProductCard.tsx
+++ b/frontend/src/components/ProductCard.tsx
@@ -1,0 +1,15 @@
+import { Product } from "@/types/product";
+
+export function ProductCard({ product }: { product: Product }) {
+  return (
+    <li className="flex items-center justify-between border-b py-3">
+      <div>
+        <p className="font-medium">{product.name}</p>
+        <p className="text-sm text-gray-500">ID: {product.id}</p>
+      </div>
+      <span className="rounded bg-gray-100 px-2 py-1 font-semibold">
+        ${product.price}
+      </span>
+    </li>
+  );
+}

--- a/frontend/src/components/ProductList.tsx
+++ b/frontend/src/components/ProductList.tsx
@@ -1,0 +1,19 @@
+import { Product } from "@/types/product";
+import { ProductCard } from "./ProductCard";
+
+export function ProductList({ products }: { products: Product[] }) {
+  if (!products?.length) {
+    return (
+      <div className="rounded-lg border p-4 text-sm text-gray-600">
+        No hay productos para mostrar.
+      </div>
+    );
+  }
+  return (
+    <ul className="divide-y">
+      {products.map((p) => (
+        <ProductCard key={p.id} product={p} />
+      ))}
+    </ul>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,0 +1,9 @@
+export const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL!;
+
+export async function apiGet<T>(path: string): Promise<T> {
+  const res = await fetch(`${API_BASE}${path}`, { cache: "no-store" });
+  if (!res.ok) {
+    throw new Error(`GET ${path} failed: ${res.status}`);
+  }
+  return res.json() as Promise<T>;
+}

--- a/frontend/src/types/product.ts
+++ b/frontend/src/types/product.ts
@@ -1,0 +1,5 @@
+export type Product = {
+  id: number;
+  name: string;
+  price: number;
+};


### PR DESCRIPTION
- Add Product type and API helper
- Create ProductCard and ProductList components
- Fetch products from `/api/products` in Home (server component)
- Update frontend README with pnpm usage and current scope

**How to test**
1. Backend running on :8080
2. cd frontend && pnpm install && pnpm dev
3. Visit http://localhost:3000 to see product list
